### PR TITLE
fix: make errors into idiomatic exceptions

### DIFF
--- a/lib/cas.dart
+++ b/lib/cas.dart
@@ -52,12 +52,12 @@ class Cas {
         } else {
           // exec completes only with valid response
           _completer_bool.completeError(
-              RedisError("exec response is not expected, but is $resp"));
+              RedisException("exec response is not expected, but is $resp"));
         }
       }).catchError((e) {
         // dont do anything
         _completer_bool.complete(true); // retry
-      }, test: (e) => e is TransactionError);
+      }, test: (e) => e is TransactionException);
     });
   }
 }

--- a/lib/command.dart
+++ b/lib/command.dart
@@ -23,16 +23,15 @@ class Command {
     this.serializer = other.serializer;
   }
 
-  Command setParser(Parser p){
+  Command setParser(Parser p) {
     this.parser = p;
     return this;
   }
 
-  Command setSerializer(Serializer s){
+  Command setSerializer(Serializer s) {
     this.serializer = s;
     return this;
   }
-  
 
   /// Serialize and send data to server
   ///
@@ -44,9 +43,9 @@ class Command {
   ///     send_object(["SET","key","value"]);
   Future send_object(Object obj) {
     try {
-      return _connection._sendraw(parser,serializer.serialize(obj)).then((v) {
+      return _connection._sendraw(parser, serializer.serialize(obj)).then((v) {
         // turn RedisError into exception
-        if (v is RedisError) {
+        if (v is RedisException) {
           return Future.error(v);
         } else {
           return v;

--- a/lib/exceptions.dart
+++ b/lib/exceptions.dart
@@ -9,27 +9,78 @@
 
 part of redis;
 
-
-// this class is returned when redis response is type error
-class RedisError  {
+@Deprecated('Use RedisException instead')
+class RedisError extends RedisException {
   String e;
-  RedisError(this.e);
-  String toString() { return "RedisError($e)";}
+
+  RedisError(this.e) : super(e);
+
+  String get error => message;
+
+  String toString() {
+    return "RedisError($message)";
+  }
+}
+
+/// This class is returned when redis response is type error
+class RedisException implements Exception {
+  String message;
+
+  RedisException(this.message);
+
+  String toString() {
+    return "RedisException($message)";
+  }
+}
+
+@Deprecated('Use RedisRuntimeException instead')
+class RedisRuntimeError extends RedisRuntimeException {
+  String e;
+
+  RedisRuntimeError(this.e) : super(e);
+
+  String toString() {
+    return "RedisRuntimeError($e)";
+  }
+
   String get error => e;
 }
 
-// thiss class is returned when parsing in client side (aka this libraray)
-// get error
-class RedisRuntimeError  {
+/// This class is returned when parsing in client side (aka this libraray)
+class RedisRuntimeException implements Exception {
   String e;
-  RedisRuntimeError(this.e);
-  String toString() { return "RedisRuntimeError($e)";}
+
+  RedisRuntimeException(this.e);
+
+  String toString() {
+    return "RedisRuntimeException($e)";
+  }
+
   String get error => e;
 }
 
-class TransactionError  {
+@Deprecated('Use TransactionException instead')
+class TransactionError extends RedisException {
   String e;
-  TransactionError(this.e);
-  String toString() { return "TranscationError($e)";}
-  String get error => e; 
+
+  TransactionError(this.e) : super(e);
+
+  String toString() {
+    return "TransactionError($e)";
+  }
+
+  String get error => e;
+}
+
+/// This class is returned when transaction fails
+class TransactionException implements Exception {
+  String e;
+
+  TransactionException(this.e);
+
+  String toString() {
+    return "TranscationException($e)";
+  }
+
+  String get error => e;
 }

--- a/lib/redisparser.dart
+++ b/lib/redisparser.dart
@@ -9,9 +9,7 @@
 
 part of redis;
 
-class RedisParser extends Parser {
-  
-}
+class RedisParser extends Parser {}
 
 class RedisParserBulkBinary extends Parser {
   Future parseBulk(LazyStream s) {
@@ -21,16 +19,16 @@ class RedisParserBulkBinary extends Parser {
         return null;
       if (i >= 0) {
         //i of bulk data
-        return s.take_n(i).then((lst) => takeCRLF(
-            s, lst)); //consume CRLF and return list
+        return s
+            .take_n(i)
+            .then((lst) => takeCRLF(s, lst)); //consume CRLF and return list
       } else {
         return Future.error(
-            RedisRuntimeError("cant process buld data less than -1"));
+            RedisRuntimeException("cant process buld data less than -1"));
       }
     });
-  }  
+  }
 }
-
 
 class Parser {
   static final UTF8 = const Utf8Codec();
@@ -53,7 +51,8 @@ class Parser {
       //now check for LF
       return s.take_n(1).then((lf) {
         if (lf[0] != LF) {
-          return Future.error(RedisRuntimeError("received element is not LF"));
+          return Future.error(
+              RedisRuntimeException("received element is not LF"));
         }
         return list;
       });
@@ -67,15 +66,15 @@ class Parser {
       if (data[0] == CR && data[1] == LF) {
         return r;
       } else {
-        return Future.error(RedisRuntimeError("expeting CRLF"));
+        return Future.error(RedisRuntimeException("expeting CRLF"));
       }
     });
   }
 
-  Future parse(LazyStream s){
+  Future parse(LazyStream s) {
     return parseredisresponse(s);
   }
-  
+
   Future parseredisresponse(LazyStream s) {
     return s.take_n(1).then((list) {
       int cmd = list[0];
@@ -92,7 +91,7 @@ class Parser {
           return parseError(s);
         default:
           return Future.error(
-              RedisRuntimeError("got element that cant not be parsed"));
+              RedisRuntimeException("got element that cant not be parsed"));
       }
     });
   }
@@ -103,8 +102,8 @@ class Parser {
     });
   }
 
-  Future<RedisError> parseError(LazyStream s) {
-    return parseSimpleString(s).then((str) => RedisError(str));
+  Future<RedisException> parseError(LazyStream s) {
+    return parseSimpleString(s).then((str) => RedisException(str));
   }
 
   Future<int> parseInt(LazyStream s) {
@@ -122,7 +121,7 @@ class Parser {
             s, UTF8.decode(lst))); //consume CRLF and return decoded list
       } else {
         return Future.error(
-            RedisRuntimeError("cant process buld data less than -1"));
+            RedisRuntimeException("cant process buld data less than -1"));
       }
     });
   }
@@ -153,7 +152,7 @@ class Parser {
         return consumeList(s, i, a);
       } else {
         return Future.error(
-            RedisRuntimeError("cant process array data less than -1"));
+            RedisRuntimeException("cant process array data less than -1"));
       }
     });
   }
@@ -163,13 +162,13 @@ class Parser {
     int sign = 1;
     var v = arr.fold(0, (dynamic a, b) {
       if (b == 45) {
-        if (a != 0) throw RedisRuntimeError("cannot parse int");
+        if (a != 0) throw RedisRuntimeException("cannot parse int");
         sign = -1;
         return 0;
       } else if ((b >= 48) && (b < 58)) {
         return a * 10 + b - 48;
       } else {
-        throw RedisRuntimeError("cannot parse int");
+        throw RedisRuntimeException("cannot parse int");
       }
     });
     return v * sign;

--- a/lib/transaction.dart
+++ b/lib/transaction.dart
@@ -10,7 +10,7 @@
 part of redis;
 
 class _WarningConnection {
-  noSuchMethod(_) => throw RedisRuntimeError("Transaction in progress. "
+  noSuchMethod(_) => throw RedisRuntimeException("Transaction in progress. "
       "Please complete Transaction with .exec");
 }
 
@@ -28,7 +28,8 @@ class Transaction extends Command {
 
   Future send_object(object) {
     if (transaction_completed) {
-      return Future.error(RedisRuntimeError("Transaction already completed."));
+      return Future.error(
+          RedisRuntimeException("Transaction already completed."));
     }
 
     Completer c = Completer();
@@ -36,9 +37,11 @@ class Transaction extends Command {
     super.send_object(object).then((msg) {
       if (msg.toString().toLowerCase() != "queued") {
         c.completeError(
-            RedisError("Could not enqueue command: " + msg.toString()));
+            RedisException("Could not enqueue command: " + msg.toString()));
       }
-    }).catchError((error){ c.completeError(error); });
+    }).catchError((error) {
+      c.completeError(error);
+    });
     return c.future;
   }
 
@@ -57,14 +60,14 @@ class Transaction extends Command {
         while (_queue.isNotEmpty) {
           _queue.removeFirst();
         }
-        // return Future.error(TransactionError("transaction error "));
-        throw TransactionError("transaction error ");
+        // return Future.error(TransactionException("transaction error "));
+        throw TransactionException("transaction error ");
         //return null;
       } else {
         if (list.length != _queue.length) {
           int? diff = list.length - _queue.length;
           //return
-          throw RedisRuntimeError(
+          throw RedisRuntimeException(
               "There was $diff command(s) executed during transcation,"
               "not going trough Transation handler");
         }

--- a/test/close_test.dart
+++ b/test/close_test.dart
@@ -23,4 +23,4 @@ main() {
   });
 }
 
-const Matcher isRedisError = TypeMatcher<RedisError>();
+const Matcher isRedisError = TypeMatcher<RedisException>();

--- a/test/error_test.dart
+++ b/test/error_test.dart
@@ -35,4 +35,4 @@ main() {
   });
 }
 
-const Matcher isRedisError = TypeMatcher<RedisError>();
+const Matcher isRedisError = TypeMatcher<RedisException>();

--- a/test/transactions_test.dart
+++ b/test/transactions_test.dart
@@ -27,7 +27,7 @@ void main() {
                 "Transaction value should not be interfered by actions outside of transaction");
       }).catchError((e) {
         print("got test error $e");
-        expect(e, TypeMatcher<TransactionError>());
+        expect(e, TypeMatcher<TransactionException>());
       });
 
       // Increase value out of transaction
@@ -39,7 +39,7 @@ void main() {
 
     //Test using command fail during transaction
     expect(() => cmd1.send_object(['SET', key, 0]),
-        throwsA(TypeMatcher<RedisRuntimeError>()),
+        throwsA(TypeMatcher<RedisRuntimeException>()),
         reason: "Command should not be usable during transaction");
 
     expect(trans.exec(), completion(equals("OK")),
@@ -49,7 +49,7 @@ void main() {
         reason: "Value should be final value $n after transaction complete");
 
     expect(() => trans.send_object(["GET", key]),
-        throwsA(TypeMatcher<RedisRuntimeError>()),
+        throwsA(TypeMatcher<RedisRuntimeException>()),
         reason:
             "Transaction object should not be usable after finishing transaction");
   });


### PR DESCRIPTION
This PR aims to make the exceptions in this library more idiomatic with Dart conventions.

This also helps solve linting errors with stronger lint configurations such as ones found on the `lint` package